### PR TITLE
Update SchemaLocator.php

### DIFF
--- a/core/lib/Thelia/Core/Propel/Schema/SchemaLocator.php
+++ b/core/lib/Thelia/Core/Propel/Schema/SchemaLocator.php
@@ -206,7 +206,7 @@ class SchemaLocator
                     continue;
                 }
 
-                $externalSchemaPath = $externalSchemaElement->getAttribute('filename');
+                $externalSchemaPath = THELIA_ROOT . $externalSchemaElement->getAttribute('filename');
 
                 if (!$fs->exists($externalSchemaPath)) {
                     continue;


### PR DESCRIPTION
Replaces the use of a relative path with an absolute path. For example, when the generation of models in the cache is called from the Thelia php console, it uses the path local/config/shema.xml. Whereas if the generation of models in the cache is called from an http request, it uses the path web/local/config/shema.xml.